### PR TITLE
Use and_then instead of unwrap in main function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,7 @@ fn main() {
         let path = opts.value_of(CONFIG_PATH_ARG).unwrap();
         let mut txt = String::new();
         fs::File::open(path)
-            .unwrap()
-            .read_to_string(&mut txt)
+            .and_then(|mut f| f.read_to_string(&mut txt))
             .expect("failed to read config");
         app::config::from_str(&txt).expect("configuration error")
     };


### PR DESCRIPTION
When reading the config file, use and_then instead of unwrapping.
This way, if an error is encountered, the user will not only see
the panic, but also the additional text "failed to read config".
It also makes it easier in the future to switch to Result based
error handling.