### PR TITLE
Add camel casing for server config attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ ARGS:
 
 ```yaml
 proxies:
-  - servers:
+  - label: default
+    servers:
       # Listen on two ports, one using a self-signed TLS certificate.
       - kind: io.l5d.tcp
         addr: 127.0.0.1:7474
       - kind: io.l5d.tls
         addr: 0.0.0.0:7575
         defaultIdentity:
-          privateKeyPath: private.pem
-          certPaths:
+          privateKey: private.pem
+          certs:
             - cert.pem
             - ../eg-ca/ca/intermediate/certs/ca-chain.cert.pem
 
@@ -72,8 +73,8 @@ proxies:
     # openssl certificate.
     client:
       tls:
-        name: "www.google.com"
-        trustCertPaths:
+        dnsName: "www.google.com"
+        trustCerts:
           - ../eg-ca/ca/intermediate/certs/ca-chain.cert.pem
           - /usr/local/etc/openssl/cert.pem
 ```

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -50,7 +50,7 @@ pub enum ServerConfig {
     // TODO support cypher suites
     // TODO support client auth
     // TODO supoprt persistence?
-    #[serde(rename = "io.l5d.tls")]
+    #[serde(rename = "io.l5d.tls", rename_all = "camelCase")]
     Tls {
         addr: net::SocketAddr,
         alpn_protocols: Option<Vec<String>>,


### PR DESCRIPTION
I noticed that the example config in the project's README was referencing config keys that have been renamed. Updating the README to reflect the correct key names. In the process I realized that we're not using camel casing for the top-level server config keys (e.g. `default_identity` instead of `defaultIdentity`), so I added a serde annotation to convert these keys to camel case.