### PR TITLE
Adds a programmatic way to exit linkerd-tcp

### DIFF
--- a/src/app/admin_http.rs
+++ b/src/app/admin_http.rs
@@ -1,9 +1,10 @@
 use futures::{Future, future};
-use hyper::{self, Get, StatusCode};
+use hyper::{self, Get, Post, StatusCode};
 use hyper::header::ContentLength;
 use hyper::server::{Service, Request, Response};
 use std::boxed::Box;
 use std::cell::RefCell;
+use std::process;
 use std::rc::Rc;
 
 pub struct Server {
@@ -42,6 +43,9 @@ impl Service for Server {
                         }
                     })
                     .boxed()
+            }
+            (&Post, "/shutdown") => {
+                process::exit(0);
             }
             _ => future::ok(Response::new().with_status(StatusCode::NotFound)).boxed(),
         }


### PR DESCRIPTION
Problem:
  Some profiling tools are not well suited for long running server
  processes and rely on the process exiting to finish their work.

Solution:
   `POST /quitquitquit` is an out-of-band signal for exiting the process. `POST`
   is used to prevent accidental curling (which uses `GET` by default) or
   web browsing from exiting the process.