### PR TITLE
Binding to all available sockets for demo purposes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ proxies:
     servers:
       # Listen on two ports, one using a self-signed TLS certificate.
       - kind: io.l5d.tcp
-        addr: 127.0.0.1:7474
+        addr: 0.0.0.0:7474
       - kind: io.l5d.tls
         addr: 0.0.0.0:7575
         defaultIdentity:

--- a/example.yml
+++ b/example.yml
@@ -1,5 +1,5 @@
 admin:
-  addr: 127.0.0.1:9989
+  addr: 0.0.0.0:9989
   metricsIntervalSecs: 10
 
 proxies:
@@ -7,7 +7,7 @@ proxies:
   - label: default
     servers:
       - kind: io.l5d.tcp
-        addr: 127.0.0.1:7474
+        addr: 0.0.0.0:7474
       # - kind: io.l5d.tls
       #   addr: 0.0.0.0:7575
       #   identities:


### PR DESCRIPTION
Problem:
  linkerd-tcp not binding to externally available ports is confusing for
  first time users.

Solution:
  Bind to 0.0.0.0