### PR TITLE
Update CONTRIBUTING with commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,50 +1,75 @@
 # Contributing to linkerd-tcp #
 
-:balloon: Thank you for using the linkerd-tcp project!
+:balloon: Thanks for your help improving the project!
 
 ## Getting Help ##
 
-If you have a question about linkerd-tcp or have encountered problems
-using linkerd-tcp, you may [file an issue][issue] or join us on
-[Slack][slack].
+If you have a question about linkerd-tcp or have encountered problems using it, you may
+[file an issue][issue] or join us on [Slack][slack].
 
-## Submitting Changes ##
+## Submitting a Pull Request ##
 
-If you'd like to make a change to linkerd-tcp, you should do the
-following:
+Do you have an improvement?
 
 1. Submit an [issue][issue] describing your proposed change.
-2. We will respond to your issue promptly.
-3. If your proposed change is accepted, and you haven't already done
-so, sign [Buoyant's Contributor License Agreement][cla].  Before we
-can accept your patches, our lawyers would like to be assured that:
-    - The code you're contributing is yours, and you have the right to
-    license it.
-    - You're granting us a license to distribute said code under the
-    terms of this agreement.
-4. Fork the linkerd-tcp repo, develop and test your code
-changes. See the project's [README](README.md) for further information
-about working in this repository.
-5. Submit a pull request against linkerd-tcp's `master` branch.
-6. Your branch may be merged once all configured checks pass,
-including:
+2. We will try to respond to your issue promptly.
+3. If your proposed change is accepted, and you haven't already done so, sign our [Contributor License Agreement][cla].
+4. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
+5. Submit a pull request against this repo's `master` branch.
+6. Your branch may be merged once all configured checks pass, including:
     - 2 code review approvals, at least 1 of which is from a buoyant member
     - The branch has passed tests in CI.
 
-### Git history ###
+## Committing
 
-Prior to submitting a pull request, please revise the commit history
-of your branch such that each commit is self-explanatory, even without
-the context of the pull request, and that it compiles & tests
-cleanly.
+We prefer squash or rebase commits so that all changes from a branch are committed to
+master a single commit.
 
-Typically, a pull request consists of a single commit.  It may
-occasionally be preferable to submit a change with several commits,
-but each should be a complete change needed to complete a larger
-feature.  Each commit should be documented appropriately.
+### Commit messages
 
-Thank you for getting involved!
-:heart: Team Buoyant
+Finalized commit messages should be in the following format:
+
+```
+Subject
+
+Problem
+
+Solution
+
+Validation
+```
+
+#### Subject
+
+- one line, <= 50 characters
+- describe what is done; not the result
+- use the active voice
+- capitalize properly
+- do not end in a period — this is a title/subject
+- reference the pull request by number
+
+##### Examples
+
+bad: server disconnects should cause dst client disconnects.
+good: Propagate disconnects from source to destination
+
+bad: support tls servers
+good: Introduce support for server-side TLS (#347)
+
+#### Problem
+
+Explain the context and why you're making that change.  What is the
+problem you're trying to solve? In some cases there is not a problem
+and this can be thought of being the motivation for your change.
+
+#### Solution
+
+Describe the modifications you've made.
+
+#### Validation
+
+Describe the testing you've done to validate your change.  Performance-related changes
+should include before- and after- benchmark results.
 
 [cla]: https://buoyant.io/cla/
 [issue]: https://github.com/linkerd/linkerd-tcp/issues/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 ## Getting Help ##
 
-If you have a question about linkerd-tcp or have encountered problems using it, you may
-[file an issue][issue] or join us on [Slack][slack].
+If you have a question about linkerd-tcp or have encountered problems using it,
+you may [file an issue][issue] or join us on [Slack][slack].
 
 ## Submitting a Pull Request ##
 
@@ -17,15 +17,17 @@ Do you have an improvement?
 4. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 5. Submit a pull request against this repo's `master` branch.
 6. Your branch may be merged once all configured checks pass, including:
-    - 2 code review approvals, at least 1 of which is from a buoyant member
+    - 2 code review approvals, at least 1 of which is from a [linkerd organization member][members].
     - The branch has passed tests in CI.
 
-## Committing
+## Committing ##
 
-We prefer squash or rebase commits so that all changes from a branch are committed to
-master a single commit.
+We prefer squash or rebase commits so that all changes from a branch are
+committed to master as a single commit. All pull requests are squashed when
+merged, but rebasing prior to merge gives you better control over the commit
+message.
 
-### Commit messages
+### Commit messages ###
 
 Finalized commit messages should be in the following format:
 
@@ -39,38 +41,43 @@ Solution
 Validation
 ```
 
-#### Subject
+#### Subject ####
 
 - one line, <= 50 characters
 - describe what is done; not the result
 - use the active voice
-- capitalize properly
+- capitalize first word and proper nouns
 - do not end in a period — this is a title/subject
-- reference the pull request by number
+- reference the github issue by number
 
-##### Examples
+##### Examples #####
 
+```
 bad: server disconnects should cause dst client disconnects.
 good: Propagate disconnects from source to destination
+```
 
+```
 bad: support tls servers
 good: Introduce support for server-side TLS (#347)
+```
 
-#### Problem
+#### Problem ####
 
-Explain the context and why you're making that change.  What is the
-problem you're trying to solve? In some cases there is not a problem
-and this can be thought of being the motivation for your change.
+Explain the context and why you're making that change.  What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of as being the motivation for your change.
 
-#### Solution
+#### Solution ####
 
 Describe the modifications you've made.
 
-#### Validation
+#### Validation ####
 
-Describe the testing you've done to validate your change.  Performance-related changes
-should include before- and after- benchmark results.
+Describe the testing you've done to validate your change.  Performance-related
+changes should include before- and after- benchmark results.
 
 [cla]: https://buoyant.io/cla/
 [issue]: https://github.com/linkerd/linkerd-tcp/issues/new
+[members]: https://github.com/orgs/linkerd/people
 [slack]: http://slack.linkerd.io/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ Do you have an improvement?
 
 1. Submit an [issue][issue] describing your proposed change.
 2. We will try to respond to your issue promptly.
-3. If your proposed change is accepted, and you haven't already done so, sign our [Contributor License Agreement][cla].
-4. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
-5. Submit a pull request against this repo's `master` branch.
+3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
+4. Submit a pull request against this repo's `master` branch.
+5. You'll need to have signed our [Contributor License Agreement][cla] before we can accept any non-trivial changes.
 6. Your branch may be merged once all configured checks pass, including:
     - 2 code review approvals, at least 1 of which is from a [linkerd organization member][members].
     - The branch has passed tests in CI.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ proxies:
 Logging may be enabled by setting `RUST_LOG=linkerd_tcp=info` on the environment.  When
 debugging, set `RUST_LOG=trace`.
 
-## Packaging ##
+## Docker ##
 
 To build the linkerd/linkerd-tcp docker image, run:
 
@@ -100,6 +100,11 @@ Try running the image with:
 docker run -v `pwd`/example.yml:/example.yml linkerd/linkerd-tcp:latest /example.yml
 ```
 
+## Code of Conduct ##
+
+This project is for everyone. We ask that our users and contributors take a few minutes to
+review our [code of conduct][coc].
+
 ## License ##
 
 Copyright 2017, Buoyant Inc. All rights reserved.
@@ -110,8 +115,9 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 <!-- references -->
+[coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [install-rust]: https://www.rust-lang.org/en-US/install.html
-[linkerd]: https://linkerd.io
+[linkerd]: https://github.com/linkerd/linkerd
 [namerd]: https://github.com/linkerd/linkerd/tree/master/namerd
 [p2c]: https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf
 [rustls]: https://github.com/ctz/rustls

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Status: _beta_
 2. Configure and run [namerd][namerd].
 3. From this repository, run: `cargo run -- example.yml`
 
+We :heart: pull requests! See [CONTRIBUTING.md](CONTRIBUTING.md) for info on
+contributing changes.
+
 ## Usage ##
 
 ```


### PR DESCRIPTION
There were some unwritten rules about commit messages in the linkerd repo.
Update these guidelines to reflect this change.

Related to https://github.com/linkerd/linkerd/pull/1183