### PR TITLE
Fix typo on rx_metrics direction label.

### DIFF
--- a/src/lb/endpoint.rs
+++ b/src/lb/endpoint.rs
@@ -36,7 +36,7 @@ struct Stats {
 impl Stats {
     fn new(metrics: tacho::Metrics) -> Stats {
         let tx_metrics = metrics.clone().labeled("direction".into(), "tx".into());
-        let rx_metrics = metrics.clone().labeled("direction".into(), "tx".into());
+        let rx_metrics = metrics.clone().labeled("direction".into(), "rx".into());
         Stats {
             connect_latency_us: metrics.scope().timing_us("connect_latency_us".into()),
             connection_ready_ms: metrics.scope().timing_ms("connection_ready_ms".into()),


### PR DESCRIPTION
Change direction label for rx_metrics to 'rx'.
Fixes #30 