### PR TITLE
Pass base_url by reference to namerd::resolve

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -188,7 +188,7 @@ impl Loader for Namerd {
               interval_secs);
         let addrs = {
             let client = Client::new(&handle);
-            namerd::resolve(url, client, interval, &ns, &path, self.metrics)
+            namerd::resolve(&url, client, interval, &ns, &path, self.metrics)
         };
         let driver = {
             let sink = self.sender.sink_map_err(|_| error!("sink error"));

--- a/src/namerd.rs
+++ b/src/namerd.rs
@@ -42,7 +42,7 @@ impl Stats {
 /// to a set of addresses.
 ///
 /// The returned stream never completes.
-pub fn resolve<C>(base_url: String,
+pub fn resolve<C>(base_url: &str,
                   client: Client<C>,
                   period: time::Duration,
                   namespace: &str,
@@ -53,8 +53,7 @@ pub fn resolve<C>(base_url: String,
 {
     let url = {
         let base = format!("{}/api/1/resolve/{}", base_url, namespace);
-        Url::parse_with_params(&base, &[("path", &target)])
-            .expect("invalid namerd url")
+        Url::parse_with_params(&base, &[("path", &target)]).expect("invalid namerd url")
     };
     let stats = Stats::new(metrics);
     let client = Rc::new(client);


### PR DESCRIPTION
Clippy notes that namerd::resolve does not need to take ownership of `base_url`:

    $ cargo clippy
    ...
    warning: this argument is passed by value, but not consumed in the function body
      --> src/namerd.rs:45:29
       |
    45 | pub fn resolve<C>(base_url: String,
       |                             ^^^^^^
       |
       = note: #[warn(needless_pass_by_value)] on by default
    help: consider changing the type to `&str`
       | pub fn resolve<C>(base_url: &str,
       = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_pass_by_valu

This doesn't have any serious impact, but it is noisy when linting.

To fix this, we pass a `&str` instead of a `String`.