### PR TITLE
Fix intermittent iperf3 failure.

### DIFF
--- a/src/lb/proxy_stream.rs
+++ b/src/lb/proxy_stream.rs
@@ -130,7 +130,7 @@ impl Future for ProxyStream {
                         // Allocate a temporary buffer to the unwritten remainder for next
                         // time.
                         self.allocs_count.incr(1);
-                        let mut p = Vec::with_capacity(rsz - wsz);
+                        let mut p = vec![0; (rsz - wsz)];
                         p.copy_from_slice(&buf[wsz..rsz]);
                         self.pending = Some(p);
                         return Ok(Async::NotReady);
@@ -138,8 +138,7 @@ impl Future for ProxyStream {
                 }
                 Err(ref e) if e.kind() == ::std::io::ErrorKind::WouldBlock => {
                     self.allocs_count.incr(1);
-                    let mut p = Vec::with_capacity(rsz);
-                    p.copy_from_slice(&buf);
+                    let p = buf.clone();
                     self.pending = Some(p);
                     return Ok(Async::NotReady);
                 }


### PR DESCRIPTION
Problem:
  copy_from_slice into a Vec panics if the length of the target Vec
and source Vec are different. Using Vec::with_capacity() returns a Vec
with length of 0.

Solution:
  Switch to the vec![value;size] macro. Alternatively, if we need a duplicate of the buffer, we
can clone() it.

Verification:
  Tested with iperf3

Fixes #47