### PR TITLE
Update dependencies to latest serde* and clap versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ doc = false
 
 [dependencies]
 bytes = "0.4"
-clap = "2.20"
+clap = "2.24"
 futures = "0.1"
 # We use not-yet-released tokio integration on master:
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ca22eae" }
@@ -24,10 +24,10 @@ log = "0.3"
 rand = "0.3"
 pretty_env_logger = "0.1"
 rustls = "0.8"
-serde = "0.9"
-serde_derive = "0.9"
-serde_json = "0.9"
-serde_yaml = "0.6"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+serde_yaml = "0.7"
 tacho = "0.3"
 tokio-core = "0.1"
 tokio-io = "0.1"


### PR DESCRIPTION
Serde 1.0 was released on April 20 (https://github.com/serde-rs/serde/releases/tag/v1.0.0). Confirmed to compile and run locally with new dependency versions. @stevej 