### PR TITLE
Make the Dispatcher implement Future

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ routers:
   # Each router has a 'label' for reporting purposes.
   - label: default
 
+    # Each router is configured to resolve names.
+    # Currently, only namerd's HTTP interface is supported:
+    interpreter:
+      kind: io.l5d.namerd.http
+      baseUrl: http://localhost:4180
+      namespace: default
+      periodSecs: 20
+
     servers:
 
       # Each router has one or more 'servers' listening for incoming connections.
@@ -100,14 +108,6 @@ routers:
             certs:
               - cert.pem
               - ../eg-ca/ca/intermediate/certs/ca-chain.cert.pem
-
-    # Each router is configured to resolve names.
-    # Currently, only namerd's HTTP interface is supported:
-    interpreter:
-      kind: io.l5d.namerd.http
-      baseUrl: http://localhost:4180
-      namespace: default
-      periodSecs: 20
 
     # Clients may also be configured to perform a TLS handshake.
     client:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Status: _beta_
 
 1. Install [Rust and Cargo][install-rust].
 2. Run [namerd][namerd].  `./namerd.sh` fetches, configures, and runs namerd using a local-fs-backed discovery (in ./tmp.discovery).
-3. From this repository, run: `cargo run -- example.yml`
+3. From this repository, run: `rustup run nightly cargo run -- example.yml`
 
 We :heart: pull requests! See [CONTRIBUTING.md](CONTRIBUTING.md) for info on
 contributing changes.

--- a/example.yml
+++ b/example.yml
@@ -5,14 +5,29 @@ admin:
 routers:
 
   - label: default
+    interpreter:
+      kind: io.l5d.namerd.http
+      baseUrl: http://localhost:4180
+      namespace: default
+      periodSecs: 20
+
     servers:
       - port: 7474
         dstName: /svc/default
         connectTimeoutMs: 500
         connectionLifetimeSecs: 60
 
-    interpreter:
-      kind: io.l5d.namerd.http
-      baseUrl: http://localhost:4180
-      namespace: default
-      periodSecs: 20
+      # - port: 7473
+      #   dstName: /svc/default
+      #   connectTimeoutMs: 500
+      #   tls:
+      #     defaultIdentity:
+      #       privateKey: ../../eg-ca/foo.bird.tls/private.pem
+      #       certs:
+      #         - ../../eg-ca/foo.bird.tls/cert.pem
+      #         - ../../eg-ca/ca/intermediate/certs/ca-chain.cert.pem
+
+    client:
+      kind: io.l5d.global
+      minConnections: 3
+      connectTimeoutMs: 500

--- a/src/balancer/dispatcher.rs
+++ b/src/balancer/dispatcher.rs
@@ -44,7 +44,7 @@ pub fn new<S>(reactor: Handle,
 }
 
 /// Initiates load balanced outbound connections.
-pub struct Dispatcher<S> {
+pub struct Dispatcher<W> {
     reactor: Handle,
     timer: Timer,
 
@@ -79,7 +79,7 @@ pub struct Dispatcher<S> {
     connected: VecDeque<Connection<endpoint::Ctx>>,
 
     /// Provides new connection requests as a Stream..
-    waiters_rx: S,
+    waiters_rx: W,
 
     /// A queue of waiters that have not yet received a connection.
     waiters: VecDeque<Waiter>,
@@ -90,8 +90,8 @@ pub struct Dispatcher<S> {
     metrics: Metrics,
 }
 
-impl<S> Dispatcher<S>
-    where S: Stream<Item = Waiter>
+impl<W> Dispatcher<W>
+    where W: Stream<Item = Waiter>
 {
     /// Receives and attempts to dispatch new waiters.
     ///
@@ -184,7 +184,6 @@ impl<S> Dispatcher<S>
         }
     }
 
-    //
     fn init_connecting(&mut self) {
         let available = self.endpoints.available();
         if available.is_empty() {

--- a/src/balancer/endpoint.rs
+++ b/src/balancer/endpoint.rs
@@ -1,4 +1,3 @@
-use super::super::Path;
 use super::super::connection::{Connection as _Connection, ctx};
 use super::super::connector;
 use futures::{Future, Poll};
@@ -10,9 +9,8 @@ use tacho;
 
 pub type Connection = _Connection<Ctx>;
 
-pub fn new(dst_name: Path, peer_addr: net::SocketAddr, weight: f64) -> Endpoint {
+pub fn new(peer_addr: net::SocketAddr, weight: f64) -> Endpoint {
     Endpoint {
-        dst_name,
         peer_addr,
         weight,
         state: Rc::new(RefCell::new(State::default())),
@@ -39,7 +37,6 @@ impl State {
 
 /// Represents a single concrete traffic destination
 pub struct Endpoint {
-    dst_name: Path,
     peer_addr: net::SocketAddr,
     weight: f64,
     state: Rc<RefCell<State>>,
@@ -71,7 +68,6 @@ impl Endpoint {
     pub fn connect(&self, sock: connector::Connecting, duration: &tacho::Timer) -> Connecting {
         let conn = {
             let peer_addr = self.peer_addr;
-            let dst_name = self.dst_name.clone();
             let state = self.state.clone();
             let duration = duration.clone();
             debug!("{}: connecting", peer_addr);
@@ -96,7 +92,7 @@ impl Endpoint {
                                   duration,
                                   start: Instant::now(),
                               };
-                              Ok(Connection::new(dst_name, sock, ctx))
+                              Ok(Connection::new(sock, ctx))
                           }
                       })
         };

--- a/src/balancer/factory.rs
+++ b/src/balancer/factory.rs
@@ -1,6 +1,6 @@
 use super::Balancer;
-use super::super::{ConfigError, Path};
-use super::super::connector::ConnectorFactory;
+use super::super::Path;
+use super::super::connector::{ConfigError, ConnectorFactory};
 use super::super::resolver::Resolve;
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,6 +1,5 @@
-use super::Path;
-use std::{fmt, net};
 use std::cell::RefCell;
+use std::net;
 use std::rc::Rc;
 
 pub mod ctx;
@@ -13,85 +12,30 @@ pub use self::ctx::Ctx;
 pub use self::duplex::Duplex;
 pub use self::socket::Socket;
 
-pub struct ConnectionCtx<C> {
-    local_addr: net::SocketAddr,
-    peer_addr: net::SocketAddr,
-    dst_name: Path,
-    ctx: C,
-}
-
-impl<C> fmt::Debug for ConnectionCtx<C>
-    where C: fmt::Debug
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ConnectionCtx")
-            .field("local_addr", &self.local_addr)
-            .field("peer_addr", &self.peer_addr)
-            .field("dst_name", &self.dst_name)
-            .field("ctx", &self.ctx)
-            .finish()
-    }
-}
-
-impl<C> ConnectionCtx<C>
-    where C: Ctx
-{
-    pub fn new(local_addr: net::SocketAddr,
-               peer_addr: net::SocketAddr,
-               dst_name: Path,
-               ctx: C)
-               -> ConnectionCtx<C> {
-        ConnectionCtx {
-            local_addr,
-            peer_addr,
-            dst_name,
-            ctx,
-        }
-    }
-
-    pub fn dst_name(&self) -> &Path {
-        &self.dst_name
-    }
-
-    pub fn ctx(&self) -> &C {
-        &self.ctx
-    }
-}
-
-impl<C> Ctx for ConnectionCtx<C>
-    where C: Ctx
-{
-    fn read(&mut self, sz: usize) {
-        self.ctx.read(sz);
-    }
-
-    fn wrote(&mut self, sz: usize) {
-        self.ctx.wrote(sz);
-    }
-}
-impl<C> Drop for ConnectionCtx<C> {
-    fn drop(&mut self) {}
-}
-
-/// A src or dst connection.
+/// A src or dst connection with server or client context.
 pub struct Connection<C> {
-    pub ctx: ConnectionCtx<C>,
+    /// Record infomation about the connection to be used by a load balance and/or to be
+    /// exported as serve/client-scoped metrics.
+    pub ctx: C,
+
+    /// Does networked I/O, possibly with TLS.
     pub socket: Socket,
 }
+
 impl<C: Ctx> Connection<C> {
-    pub fn new(dst: Path, socket: Socket, ctx: C) -> Connection<C> {
-        let ctx = ConnectionCtx::new(socket.local_addr(), socket.peer_addr(), dst, ctx);
+    pub fn new(socket: Socket, ctx: C) -> Connection<C> {
         Connection { socket, ctx }
     }
 
     pub fn peer_addr(&self) -> net::SocketAddr {
-        self.ctx.peer_addr
+        self.socket.peer_addr()
     }
 
     pub fn local_addr(&self) -> net::SocketAddr {
-        self.ctx.local_addr
+        self.socket.local_addr()
     }
 
+    /// Transfers data between connections bidirectionally.
     pub fn into_duplex<D: Ctx>(self,
                                other: Connection<D>,
                                buf: Rc<RefCell<Vec<u8>>>)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,25 +38,3 @@ mod server;
 
 use balancer::WeightedAddr;
 use path::Path;
-
-/// Describes a configuratin error.
-#[derive(Clone, Debug)]
-pub struct ConfigError(String);
-
-impl<'a> From<&'a str> for ConfigError {
-    fn from(msg: &'a str) -> ConfigError {
-        ConfigError(msg.into())
-    }
-}
-
-impl<'a> From<String> for ConfigError {
-    fn from(msg: String) -> ConfigError {
-        ConfigError(msg)
-    }
-}
-
-impl ::std::fmt::Display for ConfigError {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        fmt.write_str(&self.0)
-    }
-}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -6,7 +6,7 @@ use tokio_timer::{Timer, TimerError};
 
 mod config;
 mod namerd;
-pub use self::config::NamerdConfig;
+pub use self::config::{Error as ConfigError, NamerdConfig};
 pub use self::namerd::{Namerd, Addrs};
 
 #[derive(Debug)]

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,4 @@
-use super::{ConfigError, Path};
+use super::{Path, connector};
 use super::balancer::{Balancer, BalancerFactory};
 use super::resolver::Resolver;
 use futures::{Future, Poll, Async};
@@ -64,7 +64,7 @@ impl InnerRouter {
                 dst: &Path,
                 reactor: &Handle,
                 timer: &Timer)
-                -> Result<Balancer, ConfigError> {
+                -> Result<Balancer, connector::ConfigError> {
         // Try to get a balancer from the cache.
         if let Some(route) = self.routes.get(dst) {
             self.route_found.incr(1);
@@ -90,7 +90,7 @@ impl InnerRouter {
 ///
 ///
 #[derive(Clone)]
-pub struct Route(Option<Result<Balancer, ConfigError>>);
+pub struct Route(Option<Result<Balancer, connector::ConfigError>>);
 impl Future for Route {
     type Item = Balancer;
     type Error = io::Error;
@@ -99,7 +99,7 @@ impl Future for Route {
         match self.0
                   .take()
                   .expect("route must not be polled more than once") {
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("config error: {}", e))),
+            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("config error: {:?}", e))),
             Ok(selector) => Ok(Async::Ready(selector)),
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,7 +17,7 @@ use tokio_timer::Timer;
 
 mod config;
 mod sni;
-pub use self::config::ServerConfig;
+pub use self::config::{Error as ConfigError, ServerConfig};
 
 const DEFAULT_MAX_CONCURRENCY: usize = 100000;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -66,8 +66,7 @@ impl Unbound {
         &self.dst_name
     }
 
-    fn init_src_connection(dst_name: Path,
-                           src_tcp: TcpStream,
+    fn init_src_connection(src_tcp: TcpStream,
                            metrics: &Metrics,
                            tls: &Option<BoundTls>)
                            -> Box<Future<Item = Connection<SrcCtx>, Error = io::Error>> {
@@ -90,7 +89,7 @@ impl Unbound {
                                     tx_bytes_total: 0,
                                     metrics,
                                 };
-                                Connection::new(dst_name, sock, ctx)
+                                Connection::new(sock, ctx)
                             });
         Box::new(conn)
     }
@@ -152,7 +151,7 @@ impl Unbound {
 
                 // Finish accepting the connection from the server.
                 // TODO determine dst_addr dynamically.
-                let src = Unbound::init_src_connection(dst_name.clone(), src_tcp, &metrics, &tls);
+                let src = Unbound::init_src_connection(src_tcp, &metrics, &tls);
 
                 // Obtain a balancing endpoint selector for the given destination.
                 let balancer = router.route(&dst_name, &reactor, &timer);

--- a/src/server/sni.rs
+++ b/src/server/sni.rs
@@ -1,5 +1,4 @@
 use super::config::TlsServerIdentityConfig;
-use super::super::ConfigError;
 use rustls::{Certificate, ResolvesServerCert, SignatureScheme, sign};
 use rustls::internal::pemfile;
 use std::collections::HashMap;
@@ -9,10 +8,10 @@ use std::sync::Arc;
 
 pub fn new(identities: &Option<HashMap<String, TlsServerIdentityConfig>>,
            default: &Option<TlsServerIdentityConfig>)
-           -> Result<Sni, ConfigError> {
+           -> Result<Sni, Error> {
     let n_identities = identities.as_ref().map(|ids| ids.len()).unwrap_or(0);
     if default.is_none() && n_identities > 0 {
-        return Err("No TLS server identities specified".into());
+        return Err(Error::NoIdentities);
     }
     let sni = Sni {
         default: default.as_ref().map(|c| ServerIdentity::load(c)),
@@ -29,6 +28,11 @@ pub fn new(identities: &Option<HashMap<String, TlsServerIdentityConfig>>,
         },
     };
     Ok(sni)
+}
+
+#[derive(Debug)]
+pub enum Error {
+    NoIdentities,
 }
 
 pub struct Sni {


### PR DESCRIPTION
Previously `balancer::Dispatcher` implemented Sink, receiving a stream of Waiters (connection requests).  However, now that the Dispatcher manages the service discovery task as well, this decision no longer makes sense, since poll_complete() never converges to a stable Ready state.

Now, the Dispatcher is simply a Future that (currently) never completes.  I've taken this opportunity to substantially improve documentation of the balancer, I hope.

Furthermore:
* Remove many needless dst_name clones.
* Remove the vestigial ConnectionCtx type...