### PR TITLE
Add changelog entries for 0.1.1 and 0.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Switch the official Rust base docker image.
 * Remove use of deprecated downstream API members.
 * Remove dependency on nightly Rust to build linkerd-tcp.
+
 ## 0.1.0
 linkerd-tcp 0.1.0 constitutes a major rewrite.
 
@@ -47,20 +48,3 @@ Introducing linkerd-tcp. :balloon:
 * Run a TCP load balancer for the [Linkerd][https://linkerd.io] service mesh.
 * Support TLS and integrate with Namerd for service discovery.
 * Read a YAML or JSON configuration file at startup.
-
-
-+    available: tacho::Gauge,
-+    failed: tacho::Gauge,
-+    retired: tacho::Gauge,
-+    pending: tacho::Gauge,
-+    open: tacho::Gauge,
-+    waiters: tacho::Gauge,
-+    poll_time: tacho::Timer,
-+    attempts: tacho::Counter,
-+    unavailable: tacho::Counter,
-+    connects: tacho::Counter,
-+    timeouts: tacho::Counter,
-+    refused: tacho::Counter,
-+    failures: tacho::Counter,
-+    connect_latency: tacho::Timer,
-+    connection_duration: tacho::Timer,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ## In the next release
 
 ## 0.1.1
+
+linkerd-tcp 0.1.1 focuses on improving TLS support, and on updating linkerd-tcp's
+dependencies.
+
 * Trace negotiated SNI & ALPN at the end of the server handshake.
 * Improve handling and reporting of TLS configuration errors.
 * Update to latest versions of dependencies.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 ## In the next release
 
+## 0.1.1
+* Trace negotiated SNI & ALPN at the end of the server handshake.
+* Improve handling and reporting of TLS configuration errors.
+* Update to latest versions of dependencies.
+* Switch the official Rust base docker image.
+* Remove use of deprecated downstream API members.
+* Remove dependency on nightly Rust to build linkerd-tcp.
+## 0.1.0
+linkerd-tcp 0.1.0 constitutes a major rewrite.
+
+Previously, linkerd-tcp did not properly utilize tokio's task model, which lead
+to a number of performance and correctness problems. Furthermore, linkerd-tcp's
+configuration interface was substantially different from linkerd's, which
+caused some confusion.
+
+* Significant performance and correctness improvements.
+* Add support for connection and stream timeouts.
+* Add several additional metrics.
+* **Breaking change**: Change configuration file syntax to be structured like a Linkerd router:
+  * Rename `proxies` key to `routers`
+  * Change `servers` to take separate `ip` and `port` keys, rather than `addr`.
+  * Change `namerd` section in server configuration to Linkerd-style `interpreter`
+    section on a router configuration. The `path` key is now specified per-server as `dstPath`.
+
 ## 0.0.3
 
 * New admin endpoint! POST to `/shutdown` to tell the process to exit.
@@ -23,3 +47,20 @@ Introducing linkerd-tcp. :balloon:
 * Run a TCP load balancer for the [Linkerd][https://linkerd.io] service mesh.
 * Support TLS and integrate with Namerd for service discovery.
 * Read a YAML or JSON configuration file at startup.
+
+
++    available: tacho::Gauge,
++    failed: tacho::Gauge,
++    retired: tacho::Gauge,
++    pending: tacho::Gauge,
++    open: tacho::Gauge,
++    waiters: tacho::Gauge,
++    poll_time: tacho::Timer,
++    attempts: tacho::Counter,
++    unavailable: tacho::Counter,
++    connects: tacho::Counter,
++    timeouts: tacho::Counter,
++    refused: tacho::Counter,
++    failures: tacho::Counter,
++    connect_latency: tacho::Timer,
++    connection_duration: tacho::Timer,


### PR DESCRIPTION
## 0.1.1
* Trace negotiated SNI & ALPN at the end of the server handshake.
* Improve handling and reporting of TLS configuration errors.
* Update to latest versions of dependencies.
* Switch the official Rust base docker image.
* Remove use of deprecated downstream API members.
* Remove dependency on nightly Rust to build linkerd-tcp.
## 0.1.0
linkerd-tcp 0.1.0 constitutes a major rewrite.

Previously, linkerd-tcp did not properly utilize tokio's task model, which lead
to a number of performance and correctness problems. Furthermore, linkerd-tcp's
configuration interface was substantially different from linkerd's, which
caused some confusion.

* Significant performance and correctness improvements.
* Add support for connection and stream timeouts.
* Add several additional metrics.
* **Breaking change**: Change configuration file syntax to be structured like a Linkerd router:
  * Rename `proxies` key to `routers`
  * Change `servers` to take separate `ip` and `port` keys, rather than `addr`.
  * Change `namerd` section in server configuration to Linkerd-style `interpreter`
    section on a router configuration. The `path` key is now specified per-server as `dstPath`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>