### PR TITLE
specify governance and maintainers, and update copyright notices

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
+* @adleong @olix0r
+
 # William and Oliver should approve all changelog entries.
 CHANGES.md @wmorgan @olix0r

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,48 @@
+# Linkerd Governance
+
+This document defines project governance for Linkerd.
+
+## Roles
+
+There are two roles that convey decision-making powers: maintainer and
+super-maintainer. MAINTAINERS.md defines the membership of these roles.
+
+## Expectations
+
+Maintainers are responsible for one or more components, and are expected to
+contribute code, field incoming PRs, triage issues, proactively fix bugs, and
+generally perform maintainance tasks for these components.
+
+Super-maintainers are responsible for the project as a whole, and are expected
+to guide general project direction as well as being the final reviewer on PRs.
+
+## Decisionmaking
+
+Ideally, all project decisions are resolved by consensus. If this is not
+possible, maintainers may call a vote. Unless otherwise specified in this
+document, the vote will be decided by a simple majority in which each
+super-maintainer receives two votes and each maintainer receives one vote.
+
+## Changes in Maintainership
+
+New maintainers must be proposed by an existing maintainer and must be elected
+by a 2/3 majority organization vote. Maintainers can be removed by a 2/3
+majority organization vote.
+
+Super-maintainers must be proposed by an existing super-maintainer and must be
+elected by a 2/3 majority organization vote. Super-maintainers can be removed
+by a 2/3 majority organization vote.
+
+## GitHub Project Administration
+
+Maintainers will be added to the linkerd GitHub organization, and be made an
+owner of the GitHub organization.
+
+## Approving PRs
+
+All PRs must receive approval from at least one super maintainer before merge.
+
+## Changes in Governance
+
+All changes in Governance require a 2/3 majority organization vote.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,48 +1,7 @@
-# Linkerd Governance
+# Linkerd-TCP Governance
 
-This document defines project governance for Linkerd.
+Governance of Linkerd-TCP follows the same rules as that of Linkerd itself.
+These rules are described in Linkerd's GOVERNANCE.md, e.g. at https://github.com/linkerd/linkerd/blob/master/GOVERNANCE.md.
 
-## Roles
-
-There are two roles that convey decision-making powers: maintainer and
-super-maintainer. MAINTAINERS.md defines the membership of these roles.
-
-## Expectations
-
-Maintainers are responsible for one or more components, and are expected to
-contribute code, field incoming PRs, triage issues, proactively fix bugs, and
-generally perform maintainance tasks for these components.
-
-Super-maintainers are responsible for the project as a whole, and are expected
-to guide general project direction as well as being the final reviewer on PRs.
-
-## Decisionmaking
-
-Ideally, all project decisions are resolved by consensus. If this is not
-possible, maintainers may call a vote. Unless otherwise specified in this
-document, the vote will be decided by a simple majority in which each
-super-maintainer receives two votes and each maintainer receives one vote.
-
-## Changes in Maintainership
-
-New maintainers must be proposed by an existing maintainer and must be elected
-by a 2/3 majority organization vote. Maintainers can be removed by a 2/3
-majority organization vote.
-
-Super-maintainers must be proposed by an existing super-maintainer and must be
-elected by a 2/3 majority organization vote. Super-maintainers can be removed
-by a 2/3 majority organization vote.
-
-## GitHub Project Administration
-
-Maintainers will be added to the linkerd GitHub organization, and be made an
-owner of the GitHub organization.
-
-## Approving PRs
-
-All PRs must receive approval from at least one super maintainer before merge.
-
-## Changes in Governance
-
-All changes in Governance require a 2/3 majority organization vote.
-
+However, the set of maintainers is different, and is defined by the contents of
+the MAINTAINERS.md file in this repo.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+The Linkerd-tcp maintainers are:
+
+* Oliver Gould <ver@buoyant.io> @olix0r (super-maintainer)
+* Alex Leong <alex@buoyant.io> @adleong (super-maintainer)
+* Brian Smith <brian@buoyant.io> @briansmith
+* Eliza Weisman <eliza@buoyant.io> @hawkw
+* William Morgan <william@buoyant.io> @wmorgan
+
+
+<!--
+# Adding a new maintainer
+
+* Submit a PR modifying this file
+* Add maintainer to .github/CODEOWNERS
+* Obtain approvals per GOVERNANCE.md
+* Invite maintainer to https://github.com/orgs/linkerd/teams/linkerd-tcp-maintainers/members
+* Invite maintainer to https://github.com/orgs/linkerd/people
+-->

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ review our [code of conduct][coc].
 
 ## License ##
 
-Copyright 2017, Buoyant Inc. All rights reserved.
+Copyright 2017-2018 Linkerd-TCP authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use these files except in compliance with the License. You may obtain a copy of the License at
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //!
 //!
-//! Copyright 2017 Buoyant, Inc.
+//! Copyright 2017 Linkerd-TCP authors.
 
 #![deny(missing_docs)]
 #![deny(warnings)]


### PR DESCRIPTION
Since this is a part of the CNCF Linkerd project, get governance, maintainers, and copyright into shape.